### PR TITLE
add odometer

### DIFF
--- a/custom_components/evcc_intg/const.py
+++ b/custom_components/evcc_intg/const.py
@@ -830,6 +830,14 @@ SENSOR_SENSORS_PER_LOADPOINT = [
     ),
 
     ExtSensorEntityDescriptionStub(
+        tag=Tag.VEHICLEODOMETER,
+        icon="mdi:counter",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfLength.KILOMETERS,
+        device_class=None,
+        suggested_display_precision=0
+    ),
+    ExtSensorEntityDescriptionStub(
         tag=Tag.VEHICLERANGE,
         icon="mdi:ev-station",
         state_class=SensorStateClass.MEASUREMENT,

--- a/custom_components/evcc_intg/pyevcc_ha/keys.py
+++ b/custom_components/evcc_intg/pyevcc_ha/keys.py
@@ -244,7 +244,7 @@ class Tag(ApiKey, Enum):
     VEHICLENAME = ApiKey(key="vehicleName", type=EP_TYPE.LOADPOINTS, writeable=True, write_key = "vehicle")
 
     # "vehicleOdometer": 0,
-    # ???
+    VEHICLEODOMETER = ApiKey(key="vehicleOdometer", type=EP_TYPE.LOADPOINTS)
 
     # "vehicleRange": 0,
     VEHICLERANGE = ApiKey(key="vehicleRange", type=EP_TYPE.LOADPOINTS)

--- a/custom_components/evcc_intg/translations/de.json
+++ b/custom_components/evcc_intg/translations/de.json
@@ -220,6 +220,7 @@
       "sessionpriceperkwh": {"name": "Ladevorgang @@@/kWh"},
       "sessionsolarpercentage": {"name": "Ladevorgang PV Verwendung"},
 
+      "vehicleodometer": {"name": "Fahrzeug Kilometerstand"},
       "vehiclerange": {"name": "Fahrzeug Reichweite"},
       "vehiclesoc": {"name": "Fahrzeug Ladestand"},
 

--- a/custom_components/evcc_intg/translations/en.json
+++ b/custom_components/evcc_intg/translations/en.json
@@ -290,6 +290,7 @@
       "sessionpriceperkwh": {"name": "Session @@@/kWh"},
       "sessionsolarpercentage": {"name": "Session Solar usage"},
 
+      "vehicleodometer": {"name": "Vehicle odometer"},
       "vehiclerange": {"name": "Vehicle range"},
       "vehiclesoc": {"name": "Vehicle charge"},
 


### PR DESCRIPTION
This value seems to be delivered from my Enyaq reliably with `curl http://evcc-server:7070/api/state`, 2081 is the expected value.
```
        "vehicleLimitSoc": 100,
        "vehicleName": "Wattsman",
        "vehicleOdometer": 2081,                    <<<<<<<<<
        "vehicleRange": 380,
        "vehicleSoc": 83,
        "vehicleWelcomeActive": false
```

However, something does not seem to be correct yet. The icon is grey and it's not the one that I specified.

![Screenshot from 2024-10-25 22-05-19](https://github.com/user-attachments/assets/cdbb5020-e3f2-4f9b-841f-5e8d169cf966)

@marq24 Do you happen to know what's missing?