### PR TITLE
Make https evcc hosts work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ venv
 core.*
 *.iml
 .misc
+.idea
+.vscode

--- a/custom_components/evcc_intg/__init__.py
+++ b/custom_components/evcc_intg/__init__.py
@@ -409,14 +409,12 @@ class EvccBaseEntity(Entity):
 
     def __init__(self, coordinator: EvccDataUpdateCoordinator, description: EntityDescription) -> None:
         if hasattr(description, "tag"):
-            _LOGGER.error(f"Got TAG in {description}")
             self.tag = description.tag
         else:
             self.tag = None
 
         self.idx = None
         if hasattr(description, "idx"):
-            _LOGGER.error(f"Got IDX in {description}")
             self.idx = description.idx
         else:
             self.idx = None

--- a/custom_components/evcc_intg/__init__.py
+++ b/custom_components/evcc_intg/__init__.py
@@ -342,9 +342,10 @@ class EvccDataUpdateCoordinator(DataUpdateCoordinator):
 
         return result
 
-    async def async_write_tag(self, tag: Tag, value, idx: str = None, entity: Entity = None) -> dict:
+    async def async_write_tag(self, tag: Tag, value, idx_str: str = None, entity: Entity = None) -> dict:
         """Update single data"""
-        result = await self.bridge.write_tag(tag, value, idx)
+        idx = int(idx_str)
+        result = await self.bridge.write_tag(tag, value, idx_str)
         _LOGGER.debug(f"write result: {result}")
 
         if tag.key not in result or result[tag.key] is None:

--- a/custom_components/evcc_intg/__init__.py
+++ b/custom_components/evcc_intg/__init__.py
@@ -110,7 +110,7 @@ async def async_reload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
 
 class EvccDataUpdateCoordinator(DataUpdateCoordinator):
     def __init__(self, hass: HomeAssistant, config_entry):
-        _LOGGER.debug(f"starting evcc_intg for: {config_entry}")
+        _LOGGER.debug(f"starting evcc_intg for: {config_entry.options}\n{config_entry.data}")
         lang = hass.config.language.lower()
         self.name = config_entry.title
         self.bridge = EvccApiBridge(host=config_entry.options.get(CONF_HOST, config_entry.data.get(CONF_HOST)),

--- a/custom_components/evcc_intg/__init__.py
+++ b/custom_components/evcc_intg/__init__.py
@@ -372,7 +372,8 @@ class EvccDataUpdateCoordinator(DataUpdateCoordinator):
 
         return result
 
-    def _convert_time(self, value: str):
+    @staticmethod
+    def _convert_time(value: str):
         if value is not None and len(value) > 0:
             if "0001-01-01T00:00:00Z" == value:
                 return None

--- a/custom_components/evcc_intg/__init__.py
+++ b/custom_components/evcc_intg/__init__.py
@@ -138,6 +138,7 @@ class EvccDataUpdateCoordinator(DataUpdateCoordinator):
 
         # attribute creation
         self._cost_type = None
+        self._currency = "€"
         self._device_info_dict = {}
         self._loadpoint = {}
         self._vehicle = {}
@@ -210,8 +211,6 @@ class EvccDataUpdateCoordinator(DataUpdateCoordinator):
             self._currency = initdata["currency"]
             if self._currency == "EUR":
                 self._currency = "€"
-        else:
-            self._currency = "€"
 
         _LOGGER.debug(
             f"read_evcc_config: LPs: {len(self._loadpoint)} VEHs: {len(self._vehicle)} CT: '{self._cost_type}' CUR: {self._currency}")

--- a/custom_components/evcc_intg/__init__.py
+++ b/custom_components/evcc_intg/__init__.py
@@ -136,6 +136,13 @@ class EvccDataUpdateCoordinator(DataUpdateCoordinator):
         # config_entry only need for providing the '_device_info_dict'...
         self._config_entry = config_entry
 
+        # attribute creation
+        self._cost_type = None
+        self._device_info_dict = {}
+        self._loadpoint = {}
+        self._vehicle = {}
+        self._version = None
+
         super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=SCAN_INTERVAL)
 
     # Callable[[Event], Any]
@@ -170,7 +177,6 @@ class EvccDataUpdateCoordinator(DataUpdateCoordinator):
             "sw_version": self._version
         }
 
-        self._vehicle = {}
         for a_veh_name in initdata[JSONKEY_VEHICLES]:
             a_veh = initdata[JSONKEY_VEHICLES][a_veh_name]
             if "capacity" in a_veh:
@@ -184,7 +190,6 @@ class EvccDataUpdateCoordinator(DataUpdateCoordinator):
                     "capacity": None
                 }
 
-        self._loadpoint = {}
         api_index = 1
         for a_loadpoint in initdata[JSONKEY_LOADPOINTS]:
             self._loadpoint[f"{api_index}"] = {

--- a/custom_components/evcc_intg/__init__.py
+++ b/custom_components/evcc_intg/__init__.py
@@ -190,7 +190,7 @@ class EvccDataUpdateCoordinator(DataUpdateCoordinator):
             self._loadpoint[f"{api_index}"] = {
                 "name": a_loadpoint["title"],
                 "id": slugify(a_loadpoint["title"]),
-                "has_phase_auto_option": a_loadpoint["chargerPhases1p3p"],
+                "has_phase_auto_option": a_loadpoint["chargerPhases1p3p"] is not None,
                 "vehicle_key": a_loadpoint["vehicleName"],
                 "obj": a_loadpoint
             }

--- a/custom_components/evcc_intg/__init__.py
+++ b/custom_components/evcc_intg/__init__.py
@@ -197,7 +197,7 @@ class EvccDataUpdateCoordinator(DataUpdateCoordinator):
             self._loadpoint[f"{api_index}"] = {
                 "name": a_loadpoint["title"],
                 "id": slugify(a_loadpoint["title"]),
-                "has_phase_auto_option": a_loadpoint.get("chargerPhases1p3p") is not None,
+                "has_phase_auto_option": (a_loadpoint.get("chargerPhases1p3p") or a_loadpoint.get("chargerPhaseSwitching")),
                 "vehicle_key": a_loadpoint["vehicleName"],
                 "obj": a_loadpoint
             }

--- a/custom_components/evcc_intg/__init__.py
+++ b/custom_components/evcc_intg/__init__.py
@@ -45,6 +45,7 @@ SCAN_INTERVAL = timedelta(seconds=10)
 CONFIG_SCHEMA = config_val.removed(DOMAIN, raise_if_present=False)
 
 
+# noinspection PyUnusedLocal
 async def async_setup(hass: HomeAssistant, config: dict):  # pylint: disable=unused-argument
     """Set up this integration using YAML is not supported."""
     return True
@@ -196,7 +197,7 @@ class EvccDataUpdateCoordinator(DataUpdateCoordinator):
             self._loadpoint[f"{api_index}"] = {
                 "name": a_loadpoint["title"],
                 "id": slugify(a_loadpoint["title"]),
-                "has_phase_auto_option": a_loadpoint["chargerPhases1p3p"] is not None,
+                "has_phase_auto_option": a_loadpoint.get("chargerPhases1p3p") is not None,
                 "vehicle_key": a_loadpoint["vehicleName"],
                 "obj": a_loadpoint
             }

--- a/custom_components/evcc_intg/config_flow.py
+++ b/custom_components/evcc_intg/config_flow.py
@@ -45,20 +45,14 @@ class EvccFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_create_entry(title=user_input[CONF_NAME], data=user_input)
             else:
                 self._errors["base"] = "auth"
-        else:
-            user_input = {}
-            user_input[CONF_NAME] = "evcc"
-            user_input[CONF_HOST] = "http://your-evcc-ip:7070"
-            user_input[CONF_SCAN_INTERVAL] = 15
-            user_input[CONF_INCLUDE_EVCC] = False
 
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema({
-                vol.Required(CONF_NAME, default=user_input.get(CONF_NAME)): str,
-                vol.Required(CONF_HOST, default=user_input.get(CONF_HOST)): str,
-                vol.Required(CONF_SCAN_INTERVAL, default=user_input.get(CONF_SCAN_INTERVAL)): int,
-                vol.Required(CONF_INCLUDE_EVCC, default=user_input.get(CONF_INCLUDE_EVCC)): bool,
+                vol.Required(CONF_NAME, default=user_input.get(CONF_NAME, "evcc")): str,
+                vol.Required(CONF_HOST, default=user_input.get(CONF_HOST, "http://your-evcc-ip:7070")): str,
+                vol.Required(CONF_SCAN_INTERVAL, default=user_input.get(CONF_SCAN_INTERVAL, 15)): int,
+                vol.Required(CONF_INCLUDE_EVCC, default=user_input.get(CONF_INCLUDE_EVCC, False)): bool,
             }),
             last_step=True,
             errors=self._errors

--- a/custom_components/evcc_intg/config_flow.py
+++ b/custom_components/evcc_intg/config_flow.py
@@ -33,7 +33,7 @@ class EvccFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             if not user_input[CONF_HOST].startswith(("http://", "https://")):
-                if user_input[CONF_HOST].contains(":"):
+                if ":" in user_input[CONF_HOST]:
                     # we have NO schema but a colon, so assume http
                     user_input[CONF_HOST] = "http://" + user_input[CONF_HOST]
                 else:

--- a/custom_components/evcc_intg/config_flow.py
+++ b/custom_components/evcc_intg/config_flow.py
@@ -32,8 +32,13 @@ class EvccFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self._errors = {}
 
         if user_input is not None:
-            if user_input[CONF_HOST].startswith(("http://", "https://")):
-                user_input[CONF_HOST] = user_input[CONF_HOST].split("//")[1]
+            if not user_input[CONF_HOST].startswith(("http://", "https://")):
+                if user_input[CONF_HOST].contains(":"):
+                    # we have NO schema but a colon, so assume http
+                    user_input[CONF_HOST] = "http://" + user_input[CONF_HOST]
+                else:
+                    # https otherwise
+                    user_input[CONF_HOST] = "https://" + user_input[CONF_HOST]
 
             while user_input[CONF_HOST].endswith(("/", " ")):
                 user_input[CONF_HOST] = user_input[CONF_HOST][:-1]
@@ -45,6 +50,8 @@ class EvccFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_create_entry(title=user_input[CONF_NAME], data=user_input)
             else:
                 self._errors["base"] = "auth"
+
+        user_input = user_input or {}
 
         return self.async_show_form(
             step_id="user",

--- a/custom_components/evcc_intg/pyevcc_ha/__init__.py
+++ b/custom_components/evcc_intg/pyevcc_ha/__init__.py
@@ -104,7 +104,7 @@ class EvccApiBridge:
         # make sure that idx is really an int...
         _LOGGER.info(f"going to read all frequent_data from evcc@{self.host}")
         req = f"{self.host}/api/state{STATE_QUERY}"
-        _LOGGER.debug(f"GET request: ->{req}<-")
+        _LOGGER.debug(f"GET request: {req}")
         return await do_request(method = self.web_session.get(req))
 
     async def press_tag(self, tag: Tag, value, idx:str = None) -> dict:

--- a/custom_components/evcc_intg/pyevcc_ha/__init__.py
+++ b/custom_components/evcc_intg/pyevcc_ha/__init__.py
@@ -17,6 +17,38 @@ from custom_components.evcc_intg.pyevcc_ha.keys import EP_TYPE, Tag, IS_TRIGGER
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 
+async def do_request(method: Callable) -> dict:
+    async with method as res:
+        try:
+            if res.status == 200:
+                try:
+                    return await res.json()
+
+                except JSONDecodeError as json_exc:
+                    _LOGGER.warning(f"APP-API: JSONDecodeError while 'await res.json(): {json_exc}")
+
+                except ClientResponseError as io_exc:
+                    _LOGGER.warning(f"APP-API: ClientResponseError while 'await res.json(): {io_exc}")
+
+            elif res.status == 500 and int(res.headers['Content-Length']) > 0:
+                try:
+                    r_json = await res.json()
+                    return {"err": r_json}
+                except JSONDecodeError as json_exc:
+                    _LOGGER.warning(f"APP-API: JSONDecodeError while 'res.status == 500 res.json(): {json_exc}")
+
+                except ClientResponseError as io_exc:
+                    _LOGGER.warning(f"APP-API: ClientResponseError while 'res.status == 500 res.json(): {io_exc}")
+
+            else:
+                _LOGGER.warning(f"APP-API: write_value failed with http-status {res.status}")
+
+        except ClientResponseError as io_exc:
+            _LOGGER.warning(f"APP-API: write_value failed cause: {io_exc}")
+
+    return {}
+
+
 class EvccApiBridge:
     def __init__(self, host: str, web_session, lang: str = "en") -> None:
         self.host = host
@@ -58,7 +90,7 @@ class EvccApiBridge:
         _LOGGER.info(f"going to read all data from evcc@{self.host}")
         req = f"http://{self.host}/api/state"
         _LOGGER.debug(f"GET request: {req}")
-        json_resp = await self.do_request(method = self.web_session.get(req))
+        json_resp = await do_request(method = self.web_session.get(req))
         if len(json_resp) is not None:
             self._LAST_FULL_STATE_UPDATE_TS = time()
 
@@ -72,8 +104,8 @@ class EvccApiBridge:
         # make sure that idx is really an int...
         _LOGGER.info(f"going to read all frequent_data from evcc@{self.host}")
         req = f"http://{self.host}/api/state{STATE_QUERY}"
-        _LOGGER.debug(f"GET request: {req}")
-        return await self.do_request(method = self.web_session.get(req))
+        _LOGGER.debug(f"GET request: ->{req}<-")
+        return await do_request(method = self.web_session.get(req))
 
     async def press_tag(self, tag: Tag, value, idx:str = None) -> dict:
         ret = {}
@@ -112,15 +144,15 @@ class EvccApiBridge:
             if write_key == Tag.DETECTVEHICLE.write_key:
                 req = f"http://{self.host}/api/{EP_TYPE.LOADPOINTS.value}/{lp_idx}/vehicle"
                 _LOGGER.debug(f"PATCH request: {req}")
-                r_json = await self.do_request(method = self.web_session.patch(req))
+                r_json = await do_request(method = self.web_session.patch(req))
             else:
                 req = f"http://{self.host}/api/{EP_TYPE.LOADPOINTS.value}/{lp_idx}/{write_key}"
                 _LOGGER.debug(f"DELETE request: {req}")
-                r_json = await self.do_request(method = self.web_session.delete(req))
+                r_json = await do_request(method = self.web_session.delete(req))
         else:
             req = f"http://{self.host}/api/{EP_TYPE.LOADPOINTS.value}/{lp_idx}/{write_key}/{value}"
             _LOGGER.debug(f"POST request: {req}")
-            r_json = await self.do_request(method = self.web_session.post(req))
+            r_json = await do_request(method = self.web_session.post(req))
 
         if r_json is not None and len(r_json) > 0:
             if "result" in r_json:
@@ -141,13 +173,13 @@ class EvccApiBridge:
             if write_key == Tag.VEHICLEPLANSDELETE.write_key:
                 req = f"http://{self.host}/api/{EP_TYPE.VEHICLES.value}/{vehicle_id}/{write_key}"
                 _LOGGER.debug(f"DELETE request: {req}")
-                r_json = await self.do_request(method = self.web_session.delete(req))
+                r_json = await do_request(method = self.web_session.delete(req))
             else:
                 pass
         else:
             req = f"http://{self.host}/api/{EP_TYPE.VEHICLES.value}/{vehicle_id}/{write_key}/{value}"
             _LOGGER.debug(f"POST request: {req}")
-            r_json = await self.do_request(method = self.web_session.post(req))
+            r_json = await do_request(method = self.web_session.post(req))
 
         if r_json is not None and len(r_json) > 0:
             if "result" in r_json:
@@ -198,11 +230,11 @@ class EvccApiBridge:
         if value is None:
             req = f"http://{self.host}/api/{write_key}"
             _LOGGER.debug(f"DELETE request: {req}")
-            r_json = await self.do_request(method = self.web_session.delete(req))
+            r_json = await do_request(method = self.web_session.delete(req))
         else:
             req = f"http://{self.host}/api/{write_key}/{value}"
             _LOGGER.debug(f"POST request: {req}")
-            r_json = await self.do_request(method = self.web_session.post(req))
+            r_json = await do_request(method = self.web_session.post(req))
 
         if r_json is not None and len(r_json) > 0:
             if "result" in r_json:
@@ -223,11 +255,11 @@ class EvccApiBridge:
         if value is None:
             req = f"http://{self.host}/api/{EP_TYPE.LOADPOINTS.value}/{lp_idx}/{write_key}"
             _LOGGER.debug(f"DELETE request: {req}")
-            r_json = await self.do_request(method = self.web_session.delete(req))
+            r_json = await do_request(method = self.web_session.delete(req))
         else:
             req = f"http://{self.host}/api/{EP_TYPE.LOADPOINTS.value}/{lp_idx}/{write_key}/{value}"
             _LOGGER.debug(f"POST request: {req}")
-            r_json = await self.do_request(method = self.web_session.post(req))
+            r_json = await do_request(method = self.web_session.post(req))
 
         if r_json is not None and len(r_json) > 0:
             if "result" in r_json:
@@ -245,7 +277,7 @@ class EvccApiBridge:
         _LOGGER.info(f"going to write '{value}' for key '{write_key}' to evcc-vehicle{vehicle_id}@{self.host}")
         req = f"http://{self.host}/api/{EP_TYPE.VEHICLES.value}/{vehicle_id}/{write_key}/{value}"
         _LOGGER.debug(f"POST request: {req}")
-        r_json = await self.do_request(method = self.web_session.post(req))
+        r_json = await do_request(method = self.web_session.post(req))
 
         if r_json is not None and len(r_json) > 0:
             if "result" in r_json:
@@ -260,7 +292,7 @@ class EvccApiBridge:
             try:
                 req = f"http://{self.host}/api/{EP_TYPE.LOADPOINTS.value}/{idx}/plan/energy/{energy}/{rfc_date}"
                 _LOGGER.debug(f"POST request: {req}")
-                r_json = await self.do_request(method = self.web_session.post(req))
+                r_json = await do_request(method = self.web_session.post(req))
                 if r_json is not None and len(r_json) > 0:
                     if "result" in r_json:
                         self._LAST_FULL_STATE_UPDATE_TS = 0
@@ -281,7 +313,7 @@ class EvccApiBridge:
                 if vehicle_id is not None:
                     req = f"http://{self.host}/api/{EP_TYPE.VEHICLES.value}/{vehicle_id}/plan/soc/{soc}/{rfc_date}"
                     _LOGGER.debug(f"POST request: {req}")
-                    r_json = await self.do_request(method = self.web_session.post(req))
+                    r_json = await do_request(method = self.web_session.post(req))
                     if r_json is not None and len(r_json) > 0:
                         if "result" in r_json:
                             self._LAST_FULL_STATE_UPDATE_TS = 0
@@ -291,34 +323,3 @@ class EvccApiBridge:
 
             except Exception as err:
                 _LOGGER.info(f"could not find a connected vehicle at loadpoint: {idx}")
-
-    async def do_request(self, method: Callable) -> dict:
-        async with method as res:
-            try:
-                if res.status == 200:
-                    try:
-                        return await res.json()
-
-                    except JSONDecodeError as json_exc:
-                        _LOGGER.warning(f"APP-API: JSONDecodeError while 'await res.json(): {json_exc}")
-
-                    except ClientResponseError as io_exc:
-                        _LOGGER.warning(f"APP-API: ClientResponseError while 'await res.json(): {io_exc}")
-
-                elif res.status == 500 and int(res.headers['Content-Length']) > 0:
-                    try:
-                        r_json = await res.json()
-                        return {"err": r_json}
-                    except JSONDecodeError as json_exc:
-                        _LOGGER.warning(f"APP-API: JSONDecodeError while 'res.status == 500 res.json(): {json_exc}")
-
-                    except ClientResponseError as io_exc:
-                        _LOGGER.warning(f"APP-API: ClientResponseError while 'res.status == 500 res.json(): {io_exc}")
-
-                else:
-                    _LOGGER.warning(f"APP-API: write_value failed with http-status {res.status}")
-
-            except ClientResponseError as io_exc:
-                _LOGGER.warning(f"APP-API: write_value failed cause: {io_exc}")
-
-        return {}

--- a/custom_components/evcc_intg/pyevcc_ha/__init__.py
+++ b/custom_components/evcc_intg/pyevcc_ha/__init__.py
@@ -88,7 +88,7 @@ class EvccApiBridge:
 
     async def read_all_data(self) -> dict:
         _LOGGER.info(f"going to read all data from evcc@{self.host}")
-        req = f"http://{self.host}/api/state"
+        req = f"{self.host}/api/state"
         _LOGGER.debug(f"GET request: {req}")
         json_resp = await do_request(method = self.web_session.get(req))
         if len(json_resp) is not None:
@@ -103,7 +103,7 @@ class EvccApiBridge:
     async def read_frequent_data(self) -> dict:
         # make sure that idx is really an int...
         _LOGGER.info(f"going to read all frequent_data from evcc@{self.host}")
-        req = f"http://{self.host}/api/state{STATE_QUERY}"
+        req = f"{self.host}/api/state{STATE_QUERY}"
         _LOGGER.debug(f"GET request: ->{req}<-")
         return await do_request(method = self.web_session.get(req))
 
@@ -142,15 +142,15 @@ class EvccApiBridge:
         _LOGGER.info(f"going to press a button with payload '{value}' for key '{write_key}' to evcc-loadpoint{lp_idx}@{self.host}")
         if value is None:
             if write_key == Tag.DETECTVEHICLE.write_key:
-                req = f"http://{self.host}/api/{EP_TYPE.LOADPOINTS.value}/{lp_idx}/vehicle"
+                req = f"{self.host}/api/{EP_TYPE.LOADPOINTS.value}/{lp_idx}/vehicle"
                 _LOGGER.debug(f"PATCH request: {req}")
                 r_json = await do_request(method = self.web_session.patch(req))
             else:
-                req = f"http://{self.host}/api/{EP_TYPE.LOADPOINTS.value}/{lp_idx}/{write_key}"
+                req = f"{self.host}/api/{EP_TYPE.LOADPOINTS.value}/{lp_idx}/{write_key}"
                 _LOGGER.debug(f"DELETE request: {req}")
                 r_json = await do_request(method = self.web_session.delete(req))
         else:
-            req = f"http://{self.host}/api/{EP_TYPE.LOADPOINTS.value}/{lp_idx}/{write_key}/{value}"
+            req = f"{self.host}/api/{EP_TYPE.LOADPOINTS.value}/{lp_idx}/{write_key}/{value}"
             _LOGGER.debug(f"POST request: {req}")
             r_json = await do_request(method = self.web_session.post(req))
 
@@ -171,13 +171,13 @@ class EvccApiBridge:
         r_json = None
         if value is None:
             if write_key == Tag.VEHICLEPLANSDELETE.write_key:
-                req = f"http://{self.host}/api/{EP_TYPE.VEHICLES.value}/{vehicle_id}/{write_key}"
+                req = f"{self.host}/api/{EP_TYPE.VEHICLES.value}/{vehicle_id}/{write_key}"
                 _LOGGER.debug(f"DELETE request: {req}")
                 r_json = await do_request(method = self.web_session.delete(req))
             else:
                 pass
         else:
-            req = f"http://{self.host}/api/{EP_TYPE.VEHICLES.value}/{vehicle_id}/{write_key}/{value}"
+            req = f"{self.host}/api/{EP_TYPE.VEHICLES.value}/{vehicle_id}/{write_key}/{value}"
             _LOGGER.debug(f"POST request: {req}")
             r_json = await do_request(method = self.web_session.post(req))
 
@@ -228,11 +228,11 @@ class EvccApiBridge:
         _LOGGER.info(f"going to write '{value}' for key '{write_key}' to evcc-site@{self.host}")
         r_json = None
         if value is None:
-            req = f"http://{self.host}/api/{write_key}"
+            req = f"{self.host}/api/{write_key}"
             _LOGGER.debug(f"DELETE request: {req}")
             r_json = await do_request(method = self.web_session.delete(req))
         else:
-            req = f"http://{self.host}/api/{write_key}/{value}"
+            req = f"{self.host}/api/{write_key}/{value}"
             _LOGGER.debug(f"POST request: {req}")
             r_json = await do_request(method = self.web_session.post(req))
 
@@ -253,11 +253,11 @@ class EvccApiBridge:
         _LOGGER.info(f"going to write '{value}' for key '{write_key}' to evcc-loadpoint{lp_idx}@{self.host}")
         r_json = None
         if value is None:
-            req = f"http://{self.host}/api/{EP_TYPE.LOADPOINTS.value}/{lp_idx}/{write_key}"
+            req = f"{self.host}/api/{EP_TYPE.LOADPOINTS.value}/{lp_idx}/{write_key}"
             _LOGGER.debug(f"DELETE request: {req}")
             r_json = await do_request(method = self.web_session.delete(req))
         else:
-            req = f"http://{self.host}/api/{EP_TYPE.LOADPOINTS.value}/{lp_idx}/{write_key}/{value}"
+            req = f"{self.host}/api/{EP_TYPE.LOADPOINTS.value}/{lp_idx}/{write_key}/{value}"
             _LOGGER.debug(f"POST request: {req}")
             r_json = await do_request(method = self.web_session.post(req))
 
@@ -275,7 +275,7 @@ class EvccApiBridge:
             value = str(value)
 
         _LOGGER.info(f"going to write '{value}' for key '{write_key}' to evcc-vehicle{vehicle_id}@{self.host}")
-        req = f"http://{self.host}/api/{EP_TYPE.VEHICLES.value}/{vehicle_id}/{write_key}/{value}"
+        req = f"{self.host}/api/{EP_TYPE.VEHICLES.value}/{vehicle_id}/{write_key}/{value}"
         _LOGGER.debug(f"POST request: {req}")
         r_json = await do_request(method = self.web_session.post(req))
 
@@ -290,7 +290,7 @@ class EvccApiBridge:
         # before we can write something to the vehicle endpoints, we must know the vehicle_id!
         # -> so we have to grab from the loadpoint the current vehicle!
             try:
-                req = f"http://{self.host}/api/{EP_TYPE.LOADPOINTS.value}/{idx}/plan/energy/{energy}/{rfc_date}"
+                req = f"{self.host}/api/{EP_TYPE.LOADPOINTS.value}/{idx}/plan/energy/{energy}/{rfc_date}"
                 _LOGGER.debug(f"POST request: {req}")
                 r_json = await do_request(method = self.web_session.post(req))
                 if r_json is not None and len(r_json) > 0:
@@ -311,7 +311,7 @@ class EvccApiBridge:
                 int_idx = int(idx) - 1
                 vehicle_id = self._data[JSONKEY_LOADPOINTS][int_idx][Tag.VEHICLENAME.key]
                 if vehicle_id is not None:
-                    req = f"http://{self.host}/api/{EP_TYPE.VEHICLES.value}/{vehicle_id}/plan/soc/{soc}/{rfc_date}"
+                    req = f"{self.host}/api/{EP_TYPE.VEHICLES.value}/{vehicle_id}/plan/soc/{soc}/{rfc_date}"
                     _LOGGER.debug(f"POST request: {req}")
                     r_json = await do_request(method = self.web_session.post(req))
                     if r_json is not None and len(r_json) > 0:

--- a/custom_components/evcc_intg/pyevcc_ha/keys.py
+++ b/custom_components/evcc_intg/pyevcc_ha/keys.py
@@ -27,8 +27,7 @@ IS_TRIGGER: Final = "TRIGGER"
 CC_P1: Final = re.compile(r"(.)([A-Z][a-z]+)")
 CC_P2: Final = re.compile(r"([a-z0-9])([A-Z])")
 
-@staticmethod
-def _camel_to_snake(a_key: str):
+def camel_to_snake(a_key: str):
     if a_key.lower().endswith("kwh"):
         a_key = a_key[:-3] + "_kwh"
     a_key = re.sub(CC_P1, r'\1_\2', a_key)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 homeassistant>=2024.8.2
+aiohttp~=3.11.11
+voluptuous~=0.15.2


### PR DESCRIPTION
While working on a quick hack (fix) for the new `chargerPhasesSwitching` entity I found that ha-evcc wouldn't update my stats. Digging deeper I found lots of `"ADD-API: write_values failed ..."` error messages.

That's because internally ha-evcc only uses the actual host definition without the scheme ("http://" or "https://") and expects the evcc instance to be reachable via http://. Unfrotunately mine isn't so I reworked `config_flow.py` and `pyevcc/__init__.py` a bit to make them work with full scheme+host URLs.

I also left in all the changes suggested by my IDE (like direct access to private class members and such), feel free to cherry pick what you like and throw away the stuff that doesn't suit you.
