### PR TITLE
Shorter short name

### DIFF
--- a/custom_components/evcc_intg/const.py
+++ b/custom_components/evcc_intg/const.py
@@ -22,8 +22,8 @@ from custom_components.evcc_intg.pyevcc_ha.keys import Tag, GRID_CONTENT, PV_CON
 
 # Base component constants
 MANUFACTURER: Final = "marq24"
-NAME: Final = "evcc☀️🚘- Solar Charging"
-NAME_SHORT: Final = "evcc☀️🚘"
+NAME: Final = "evcc ☀️🚘 Solar Charging"
+NAME_SHORT: Final = "evcc"
 DOMAIN: Final = "evcc_intg"
 ISSUE_URL: Final = "https://github.com/marq24/ha-evcc/issues"
 


### PR DESCRIPTION
Hi @marq24,

I like, that you've included the 🚘☀️ combination in the extension name. I've changed the spaces a bit so that it can act as the divider between name and claim (drop the `-`).

I'd also like to remove the emojis from the short name because this is used a lot throughout the home assistant UI. Especially in lists. My eyes get emoji overflow 👇

<img width="417" height="761" alt="Bildschirmfoto 2025-11-14 um 14 31 11" src="https://github.com/user-attachments/assets/9a90eb74-3344-4f75-be1e-79f3f0d93f0a" />
