### PR TITLE
Add Solar Energy Statistics Sensors

### DIFF
--- a/custom_components/evcc_intg/__init__.py
+++ b/custom_components/evcc_intg/__init__.py
@@ -676,10 +676,15 @@ class EvccDataUpdateCoordinator(DataUpdateCoordinator):
     def read_tag_statistics(self, tag: Tag):
         if JSONKEY_STATISTICS in self.data:
             if tag.subtype in self.data[JSONKEY_STATISTICS]:
-                if tag.json_key in self.data[JSONKEY_STATISTICS][tag.subtype]:
-                    return self.data[JSONKEY_STATISTICS][tag.subtype][tag.json_key]
-                elif tag.json_key_alias is not None and tag.json_key_alias in self.data[JSONKEY_STATISTICS]:
-                    return self.data[JSONKEY_STATISTICS][tag.subtype][tag.json_key_alias]
+                period_data = self.data[JSONKEY_STATISTICS][tag.subtype]
+                if tag.json_key == "solarKWh":
+                    charged = period_data.get("chargedKWh", 0) or 0
+                    solar_pct = period_data.get("solarPercentage", 0) or 0
+                    return round(float(charged) * float(solar_pct) / 100.0, 4)
+                if tag.json_key in period_data:
+                    return period_data[tag.json_key]
+                elif tag.json_key_alias is not None and tag.json_key_alias in period_data:
+                    return period_data[tag.json_key_alias]
 
     def read_tag_loadpoint(self, tag: Tag, loadpoint_idx: int = None):
         if loadpoint_idx is not None and len(self.data[JSONKEY_LOADPOINTS]) > loadpoint_idx - 1:

--- a/custom_components/evcc_intg/const.py
+++ b/custom_components/evcc_intg/const.py
@@ -1167,6 +1167,45 @@ SENSOR_ENTITIES = [
         entity_registry_enabled_default=False
     ),
     ExtSensorEntityDescription(
+        tag=Tag.STATTOTALSOLARKWH,
+        key=Tag.STATTOTALSOLARKWH.entity_key,
+        icon="mdi:solar-power",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        suggested_display_precision=4
+    ),
+    ExtSensorEntityDescription(
+        tag=Tag.STATTHISYEARSOLARKWH,
+        key=Tag.STATTHISYEARSOLARKWH.entity_key,
+        icon="mdi:solar-power",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        suggested_display_precision=4,
+        entity_registry_enabled_default=False
+    ),
+    ExtSensorEntityDescription(
+        tag=Tag.STAT365SOLARKWH,
+        key=Tag.STAT365SOLARKWH.entity_key,
+        icon="mdi:solar-power",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        suggested_display_precision=4,
+        entity_registry_enabled_default=False
+    ),
+    ExtSensorEntityDescription(
+        tag=Tag.STAT30SOLARKWH,
+        key=Tag.STAT30SOLARKWH.entity_key,
+        icon="mdi:solar-power",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        suggested_display_precision=4,
+        entity_registry_enabled_default=False
+    ),
+    ExtSensorEntityDescription(
         tag=Tag.STAT30AVGPRICE,
         key=Tag.STAT30AVGPRICE.entity_key,
         icon="mdi:cash-multiple",

--- a/custom_components/evcc_intg/pyevcc_ha/__init__.py
+++ b/custom_components/evcc_intg/pyevcc_ha/__init__.py
@@ -19,7 +19,7 @@ from custom_components.evcc_intg.pyevcc_ha.const import (
     SESSIONS_KEY_RAW,
     SESSIONS_KEY_TOTAL,
     SESSIONS_KEY_VEHICLES,
-    SESSIONS_KEY_LOADPOINTS
+    SESSIONS_KEY_LOADPOINTS,
 )
 from custom_components.evcc_intg.pyevcc_ha.keys import EP_TYPE, Tag, IS_TRIGGER
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator

--- a/custom_components/evcc_intg/pyevcc_ha/keys.py
+++ b/custom_components/evcc_intg/pyevcc_ha/keys.py
@@ -22,7 +22,7 @@ from custom_components.evcc_intg.pyevcc_ha.const import (
     JSONKEY_STATISTICS_30D,
     BATTERY_LIST,
     SESSIONS_KEY_VEHICLES,
-    SESSIONS_KEY_LOADPOINTS
+    SESSIONS_KEY_LOADPOINTS,
 )
 
 # from aenum import Enum, extend_enum
@@ -476,6 +476,11 @@ class Tag(ApiKey, Enum):
     CHARGING_SESSIONS_LOADPOINT_COST = ApiKey(entity_key="charging_sessions_loadpoint_cost", json_key="cost", type=EP_TYPE.SESSIONS, subtype=SESSIONS_KEY_LOADPOINTS)
     CHARGING_SESSIONS_LOADPOINT_ENERGY = ApiKey(entity_key="charging_sessions_loadpoint_chargedenergy", json_key="chargedEnergy", type=EP_TYPE.SESSIONS, subtype=SESSIONS_KEY_LOADPOINTS)
     CHARGING_SESSIONS_LOADPOINT_DURATION = ApiKey(entity_key="charging_sessions_loadpoint_chargeduration", json_key="chargeDuration", type=EP_TYPE.SESSIONS, subtype=SESSIONS_KEY_LOADPOINTS)
+
+    STATTOTALSOLARKWH = ApiKey(entity_key="statTotalSolarKWh", json_key="solarKWh", type=EP_TYPE.STATISTICS, subtype=JSONKEY_STATISTICS_TOTAL)
+    STATTHISYEARSOLARKWH = ApiKey(entity_key="statThisYearSolarKWh", json_key="solarKWh", type=EP_TYPE.STATISTICS, subtype=JSONKEY_STATISTICS_THISYEAR)
+    STAT365SOLARKWH = ApiKey(entity_key="stat365SolarKWh", json_key="solarKWh", type=EP_TYPE.STATISTICS, subtype=JSONKEY_STATISTICS_365D)
+    STAT30SOLARKWH = ApiKey(entity_key="stat30SolarKWh", json_key="solarKWh", type=EP_TYPE.STATISTICS, subtype=JSONKEY_STATISTICS_30D)
 
     ###################################
     # EV-OPTIMIZATION

--- a/custom_components/evcc_intg/translations/de.json
+++ b/custom_components/evcc_intg/translations/de.json
@@ -350,6 +350,11 @@
       "stat30avgprice": {"name": "Statistik: letzten 30 Tage Ø Preis"},
       "stat30avgco2": {"name": "Statistik: letzten 30 Tage Ø CO₂"},
 
+      "stattotalsolarkwh": {"name": "Statistik: gesamt Solar-kWh"},
+      "statthisyearsolarkwh": {"name": "Statistik: dieses Jahr Solar-kWh"},
+      "stat365solarkwh": {"name": "Statistik: letzten 365 Tage Solar-kWh"},
+      "stat30solarkwh": {"name": "Statistik: letzten 30 Tage Solar-kWh"},
+
       "tariff_api_solar": {"name": "Solar Prognose [Tariff-API]"},
       "tariff_api_grid": {"name": "Stromtarife [Tariff-API]"},
       "tariff_api_feedin": {"name": "Einspeisetarife [Tariff-API]"},

--- a/custom_components/evcc_intg/translations/en.json
+++ b/custom_components/evcc_intg/translations/en.json
@@ -420,6 +420,11 @@
       "stat30avgprice": {"name": "Statistics: Last 30 days Ø Price"},
       "stat30avgco2": {"name": "Statistics: Last 30 days Ø CO₂"},
 
+      "stattotalsolarkwh": {"name": "Statistics: Total Solar energy"},
+      "statthisyearsolarkwh": {"name": "Statistics: This year Solar energy"},
+      "stat365solarkwh": {"name": "Statistics: Last 365 days Solar energy"},
+      "stat30solarkwh": {"name": "Statistics: Last 30 days Solar energy"},
+
       "tariff_api_solar": {"name": "Solar Prognoses [Tariff-API]"},
       "tariff_api_grid": {"name": "Grid Tariffs [Tariff-API]"},
       "tariff_api_feedin": {"name": "Feedin Tariffs [Tariff-API]"},


### PR DESCRIPTION
Hi Matthias,

this PR adds four new sensors that report the amount of solar/PV energy used for EV charging, broken down by time period:

stat_total_solar_kwh — all time
stat_this_year_solar_kwh — current year
stat365_solar_kwh — rolling 365 days
stat30_solar_kwh — rolling 30 days
These complement the existing chargedKWh statistics sensors and give a complete view of how much charging energy came from solar vs. the grid.

Motivation

In the [hass-evcc-card](https://github.com/bw/hass-evcc-card) I want to show stacked bar charts of EV charging -  solar share vs. grid share - per day, month, and year. To render these charts, Home Assistant's recorder needs TOTAL_INCREASING energy sensors for both total and solar kWh. The total kWh sensors already exist; this PR adds the missing solar side.

How it works

EVCC already exposes chargedKWh and solarPercentage per time period in its statistics endpoint. The solar kWh value is derived from these two fields (chargedKWh × solarPercentage / 100), which is mathematically equivalent to summing solar contributions across all individual sessions. No additional API calls or polling is needed. The sensors update in real time via the existing WebSocket connection.