### PR TITLE
Fix SMARTCOSTLIMIT / BATTERYGRIDCHARGELIMIT minimum value for deeply negative spot prices

### DIFF
--- a/custom_components/evcc_intg/const.py
+++ b/custom_components/evcc_intg/const.py
@@ -314,7 +314,7 @@ NUMBER_ENTITIES = [
         icon = "mdi:cash-multiple",
         mode = NumberMode.BOX,
         native_max_value=2.50,
-        native_min_value=-0.05,
+        native_min_value=-0.50,
         native_step=0.005,
         native_unit_of_measurement="@@@/kWh"
     ),
@@ -370,7 +370,7 @@ NUMBER_ENTITIES_PER_LOADPOINT = [
         icon = "mdi:cash-multiple",
         mode = NumberMode.BOX,
         native_max_value=2.50,
-        native_min_value=-0.05,
+        native_min_value=-0.50,
         native_step=0.005,
         native_unit_of_measurement="@@@/kWh",
     ),

--- a/custom_components/evcc_intg/number.py
+++ b/custom_components/evcc_intg/number.py
@@ -23,7 +23,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, add_
             if coordinator._currency != "€":
                 description = replace(
                     description,
-                    native_max_value = description.native_max_value * 10
+                    native_max_value = description.native_max_value * 10,
+                    native_min_value = description.native_min_value * 10
                 )
 
         entity = EvccNumber(coordinator, description)
@@ -83,7 +84,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, add_
                     elif coordinator._currency != "€":
                         description = replace(
                             description,
-                            native_max_value = a_stub.native_max_value * 10
+                            native_max_value = a_stub.native_max_value * 10,
+                            native_min_value = a_stub.native_min_value * 10
                         )
 
                 entity = EvccNumber(coordinator, description)


### PR DESCRIPTION
## Problem

The `SMARTCOSTLIMIT` and `BATTERYGRIDCHARGELIMIT` number entities were defined
with `native_min_value=-0.05` (= -5 ct/kWh). Users on dynamic tariffs (Tibber,
aWATTar, Nordpool, etc.) regularly see spot prices well below that threshold.
Values of -20 ct/kWh or lower are common during periods of surplus renewable
generation. The HA entity clamped the input at -0.05 €/kWh, making it
impossible to set a smart charging threshold low enough to match those prices,
even though evcc's own UI already handles and displays these values correctly.

A second, related issue existed in `number.py`: the non-EUR currency branch
(SEK, NOK, DKK - scaled ×10 relative to EUR) applied the ×10 multiplier to
`native_max_value` but **not** to `native_min_value`. This meant the lower
bound was inconsistently left unscaled for Scandinavian users.

## Changes

**`custom_components/evcc_intg/const.py`**
- `BATTERYGRIDCHARGELIMIT`: `native_min_value` `-0.05` → `-0.50` (= -50 ct/kWh)
- `SMARTCOSTLIMIT` (per-loadpoint stub): `native_min_value` `-0.05` → `-0.50` (= -50 ct/kWh)

**`custom_components/evcc_intg/number.py`**
- `BATTERYGRIDCHARGELIMIT` non-EUR branch: also scale `native_min_value` by ×10
- `SMARTCOSTLIMIT` non-EUR branch: also scale `native_min_value` by ×10

This yields consistent ranges:

| Currency | min | max |
|---|---|---|
| EUR (€) | -0.50 €/kWh | 2.50 €/kWh |
| SEK/NOK/DKK | -5.0 /kWh | 25.0 /kWh |

## Why -0.50 €/kWh?

The value of -50 ct/kWh covers all realistic negative spot price scenarios
observed on European day-ahead markets to date, while keeping the range
sensible. The CO2 branch and all other number entities are unaffected.
