### PR TITLE
Add effectivePlanStrategy entities (charging strategy & pre-conditioning)

### DIFF
--- a/custom_components/evcc_intg/__init__.py
+++ b/custom_components/evcc_intg/__init__.py
@@ -696,6 +696,18 @@ class EvccDataUpdateCoordinator(DataUpdateCoordinator):
             #    _LOGGER.error(f"valA? {self.data[JSONKEY_LOADPOINTS][loadpoint_idx - 1]}")
             #    _LOGGER.error(f"valB? {self.data[JSONKEY_LOADPOINTS][loadpoint_idx - 1][tag.key]}")
 
+            if tag == Tag.EFFECTIVEPLANSTRATEGY_CONTINUOUS or tag == Tag.EFFECTIVEPLANSTRATEGY_PRECONDITION:
+                eps = self.data[JSONKEY_LOADPOINTS][loadpoint_idx - 1].get("effectivePlanStrategy")
+                if eps is not None:
+                    if tag == Tag.EFFECTIVEPLANSTRATEGY_CONTINUOUS:
+                        return "continuous" if eps.get("continuous", False) else "late"
+                    else:
+                        minutes = (eps.get("precondition") or 0) // 60
+                        if minutes in (0, 15, 30, 60, 120):
+                            return str(minutes)
+                        return "all"
+                return None
+
             value = None
             if tag.json_key in self.data[JSONKEY_LOADPOINTS][loadpoint_idx - 1]:
                 value = self.data[JSONKEY_LOADPOINTS][loadpoint_idx - 1][tag.json_key]
@@ -786,6 +798,22 @@ class EvccDataUpdateCoordinator(DataUpdateCoordinator):
             return await self.bridge.write_vehicle_plan(vehicle_id=vehicle_name, soc=None, rfc_date=None, precondition=-1)
         else:
             return await self.bridge.write_loadpoint_plan(idx=loadpoint_idx, energy=None, rfc_date=None)
+
+    async def async_write_plan_strategy(self, lp_idx: int, continuous: bool, precondition_seconds: int, entity: Entity = None) -> dict:
+        vehicle_id = self.data[JSONKEY_LOADPOINTS][lp_idx - 1].get(Tag.LP_VEHICLENAME.json_key) if len(self.data[JSONKEY_LOADPOINTS]) >= lp_idx else None
+        result = await self.bridge.write_plan_strategy(str(lp_idx), continuous, precondition_seconds, vehicle_id=vehicle_id)
+        _LOGGER.debug(f"write plan_strategy result: {result}")
+        try:
+            if len(self.data[JSONKEY_LOADPOINTS]) >= lp_idx:
+                self.data[JSONKEY_LOADPOINTS][lp_idx - 1]["effectivePlanStrategy"] = {"continuous": continuous, "precondition": precondition_seconds}
+        except Exception as err:
+            _LOGGER.debug(f"async_write_plan_strategy: {err}")
+        if entity is not None:
+            if self.bridge.ws_connected:
+                entity.async_write_ha_state()
+            else:
+                entity.async_schedule_update_ha_state(force_refresh=True)
+        return result
 
     async def async_press_tag(self, tag: Tag, value, idx: str = None, entity: Entity = None) -> dict:
         result = await self.bridge.press_tag(tag, value, idx)

--- a/custom_components/evcc_intg/const.py
+++ b/custom_components/evcc_intg/const.py
@@ -504,7 +504,21 @@ SELECT_ENTITIES_PER_LOADPOINT = [
         #device_class= NumberDeviceClass.BATTERY,
         options=Tag.BATTERYBOOSTLIMIT.options,
         integrated_supported=False
-    )
+    ),
+    ExtSelectEntityDescriptionStub(
+        tag=Tag.EFFECTIVEPLANSTRATEGY_CONTINUOUS,
+        entity_category=EntityCategory.CONFIG,
+        icon="mdi:calendar-clock",
+        options=Tag.EFFECTIVEPLANSTRATEGY_CONTINUOUS.options,
+        integrated_supported=False
+    ),
+    ExtSelectEntityDescriptionStub(
+        tag=Tag.EFFECTIVEPLANSTRATEGY_PRECONDITION,
+        entity_category=EntityCategory.CONFIG,
+        icon="mdi:car-clock",
+        options=Tag.EFFECTIVEPLANSTRATEGY_PRECONDITION.options,
+        integrated_supported=False
+    ),
 ]
 
 SENSOR_ENTITIES_GRID_AS_PREFIX = [

--- a/custom_components/evcc_intg/pyevcc_ha/__init__.py
+++ b/custom_components/evcc_intg/pyevcc_ha/__init__.py
@@ -592,6 +592,25 @@ class EvccApiBridge:
         except Exception as err:
             _LOGGER.info(f"could not write to loadpoint: {idx}")
 
+    async def write_plan_strategy(self, lp_idx: str, continuous: bool, precondition: int, vehicle_id: str | None = None) -> dict:
+        try:
+            payload = {"continuous": continuous, "precondition": precondition}
+            if vehicle_id:
+                req = f"{self.host}/api/{EP_TYPE.VEHICLES.value}/{vehicle_id}/plan/strategy"
+                _LOGGER.info(f"going to write plan/strategy {payload} to evcc-vehicle{vehicle_id}@{self.host}")
+            else:
+                req = f"{self.host}/api/{EP_TYPE.LOADPOINTS.value}/{lp_idx}/plan/strategy"
+                _LOGGER.info(f"going to write plan/strategy {payload} to evcc-loadpoint{lp_idx}@{self.host}")
+            _LOGGER.debug(f"POST request: {req}")
+            r_json = await _do_request(method=self.web_session.post(url=req, json=payload, ssl=False))
+            if r_json is not None and ((hasattr(r_json, "len") and len(r_json) > 0) or isinstance(r_json, (Number, str))):
+                return r_json
+            else:
+                return {"err": "no response from evcc"}
+        except Exception as err:
+            _LOGGER.error(f"could not write plan strategy: {err}")
+            return {"err": f"could not write plan strategy: {err}"}
+
     async def write_vehicle_plan(self, vehicle_id:str, soc:str, rfc_date:str, precondition: int | None = None):
         if vehicle_id is not None:
             try:

--- a/custom_components/evcc_intg/pyevcc_ha/keys.py
+++ b/custom_components/evcc_intg/pyevcc_ha/keys.py
@@ -425,6 +425,11 @@ class Tag(ApiKey, Enum):
     # delete plan button
     PLANDELETE = ApiKey(json_key="planDelete", type=EP_TYPE.LOADPOINTS, writeable=True, write_key="plan/energy")
 
+    # "effectivePlanStrategy": {"continuous": bool}, -> charging strategy: "continuous" or "late" (günstigst)
+    EFFECTIVEPLANSTRATEGY_CONTINUOUS = ApiKey(json_key="planStrategyContinuous", type=EP_TYPE.LOADPOINTS, writeable=True, options=["continuous", "late"])
+    # "effectivePlanStrategy": {"precondition": int (seconds)}, -> pre-conditioning duration in minutes (0, 15, 30, 60, 120 or all)
+    EFFECTIVEPLANSTRATEGY_PRECONDITION = ApiKey(json_key="planStrategyPrecondition", type=EP_TYPE.LOADPOINTS, writeable=True, options=["0", "15", "30", "60", "120", "all"])
+
     ###################################
     # VEHICLE
     ###################################

--- a/custom_components/evcc_intg/select.py
+++ b/custom_components/evcc_intg/select.py
@@ -269,6 +269,20 @@ class EvccSelect(EvccBaseEntity, SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         try:
+            if self.tag == Tag.EFFECTIVEPLANSTRATEGY_CONTINUOUS:
+                continuous = (option == "continuous")
+                precondition_opt = self.coordinator.read_tag(Tag.EFFECTIVEPLANSTRATEGY_PRECONDITION, self.lp_idx)
+                precondition_sec = 604800 if precondition_opt == "all" else int(precondition_opt or 0) * 60
+                await self.coordinator.async_write_plan_strategy(self.lp_idx, continuous, precondition_sec, self)
+                return
+
+            if self.tag == Tag.EFFECTIVEPLANSTRATEGY_PRECONDITION:
+                continuous_opt = self.coordinator.read_tag(Tag.EFFECTIVEPLANSTRATEGY_CONTINUOUS, self.lp_idx)
+                continuous = (continuous_opt == "continuous") if continuous_opt is not None else False
+                precondition_sec = 604800 if option == "all" else int(option) * 60
+                await self.coordinator.async_write_plan_strategy(self.lp_idx, continuous, precondition_sec, self)
+                return
+
             if "null" == str(option):
                 await self.coordinator.async_write_tag(self.tag, None, self.lp_idx, self)
             else:

--- a/custom_components/evcc_intg/translations/de.json
+++ b/custom_components/evcc_intg/translations/de.json
@@ -245,7 +245,25 @@
         }
       },
       "mincurrent": {"name": "Min. Ladestrom"},
-      "maxcurrent": {"name": "Max. Ladestrom"}
+      "maxcurrent": {"name": "Max. Ladestrom"},
+      "planstrategycontinuous": {
+        "name": "Ladeplanung: Optimierung",
+        "state": {
+          "continuous": "Kontinuierlich",
+          "late": "Günstigst"
+        }
+      },
+      "planstrategyprecondition": {
+        "name": "Ladeplanung: Spätes Laden",
+        "state": {
+          "0": "Nein",
+          "15": "15 Minuten",
+          "30": "30 Minuten",
+          "60": "1 Stunde",
+          "120": "2 Stunden",
+          "all": "Alles"
+        }
+      }
     },
     "sensor": {
       "chargecurrent": {"name": "Ladestrom"},

--- a/custom_components/evcc_intg/translations/en.json
+++ b/custom_components/evcc_intg/translations/en.json
@@ -315,6 +315,24 @@
       },
       "maxcurrent": {
         "name": "Charging Current Max."
+      },
+      "planstrategycontinuous": {
+        "name": "Charging plan: Optimization",
+        "state": {
+          "continuous": "Continuous",
+          "late": "Most favorable"
+        }
+      },
+      "planstrategyprecondition": {
+        "name": "Charging plan: Late charging",
+        "state": {
+          "0": "No",
+          "15": "15 minutes",
+          "30": "30 minutes",
+          "60": "1 hour",
+          "120": "2 hours",
+          "all": "All"
+        }
       }
     },
     "sensor": {


### PR DESCRIPTION
## Add `effectivePlanStrategy` entities: Charging Plan Optimization & Late Charging

This PR exposes the two fields of the `effectivePlanStrategy` loadpoint object as configurable select entities in Home Assistant, allowing users to control the evcc charging strategy directly from HA. Including automations and dashboards.

### New entities (per loadpoint)

| Entity | Type | Options |
|---|---|---|
| `Charging plan: Optimization` | `select` | `Continuous` / `Most favorable` |
| `Charging plan: Late charging` | `select` | `No` / `15 min` / `30 min` / `1 hour` / `2 hours` / `All` |

Both entities write to `POST /api/vehicles/{name}/plan/strategy` when a vehicle is connected, and fall back to `POST /api/loadpoints/{id}/plan/strategy` otherwise. Both fields are always sent together as `{"continuous": bool, "precondition": int}`, as required by the API.

The "All" option maps to 604800 seconds (168 hours), which is evcc's internal representation for "precondition for the entire planning window".

Both entities are marked `integrated_supported=False` as they are only meaningful for EV charging loadpoints.

---

### Style notes

This time I made a deliberate effort to match your coding style as closely as possible to reduce integration effort.

**Two intentional deviations from your standard pattern:**

1. **Dedicated `async_write_plan_strategy()` coordinator method** instead of routing through `async_write_tag()` / `write_tag()`.  
   *Reason:* `effectivePlanStrategy` requires both `continuous` and `precondition` to be sent together in a single POST to a non-standard endpoint. The standard single-key write path cannot express this.

2. **Special-case reading block at the top of `read_tag_loadpoint()`**, plus **synthetic `json_key` values** (`planStrategyContinuous`, `planStrategyPrecondition`).  
   *Reason:* The data lives in a nested sub-object (`effectivePlanStrategy: {continuous, precondition}`) rather than as top-level loadpoint keys, and requires translation (bool → option string, seconds → discrete step). Synthetic keys are necessary to give each tag a unique identity within the framework. The special-case block returns early, so it does not affect the existing generic lookup path.
