### PR TITLE
Fix `charge_power` (and probably other values) not properly updated o…

### DIFF
--- a/custom_components/evcc_intg/pyevcc_ha/__init__.py
+++ b/custom_components/evcc_intg/pyevcc_ha/__init__.py
@@ -98,17 +98,23 @@ def calculate_session_sums(sessions_resp, json_resp: dict):
                 charge_duration = a_session_entry.get("chargeDuration", 0)
                 if charge_duration is None or not isinstance(charge_duration, Number):
                     charge_duration = 0
-                    _LOGGER.info(f"calculate_session_sums(): invalid 'charge_duration' in session entry: {a_session_entry}")
+                    # de-noisify logs since None is a valid value for 'charge_duration' and we don't want to spam the logs with this
+                    if not isinstance(charge_duration, Number):
+                        _LOGGER.info(f"calculate_session_sums(): invalid 'charge_duration' in session entry: {a_session_entry}")
 
             charged_energy = a_session_entry.get("chargedEnergy", 0)
             if charged_energy is None or not isinstance(charged_energy, Number):
                 charged_energy = 0
-                _LOGGER.info(f"calculate_session_sums(): invalid 'charged_energy' in session entry: {a_session_entry}")
+                # de-noisify logs since None is a valid value for 'charged_energy' and we don't want to spam the logs with this
+                if not isinstance(charged_energy, Number):
+                    _LOGGER.info(f"calculate_session_sums(): invalid 'charged_energy' in session entry: {a_session_entry}")
 
             cost = a_session_entry.get("price", 0)
             if cost is None or not isinstance(cost, Number):
                 cost = 0
-                _LOGGER.info(f"calculate_session_sums(): invalid 'costs' in session entry: {a_session_entry}")
+                # de-noisify logs since None is a valid value for 'cost' and we don't want to spam the logs with this
+                if not isinstance(cost, Number):
+                    _LOGGER.info(f"calculate_session_sums(): invalid 'costs' in session entry: {a_session_entry}")
 
             _add_to_sums(vehicle_sums, a_vehicle, charge_duration, charged_energy, cost)
             _add_to_sums(loadpoint_sums, a_loadpoint, charge_duration, charged_energy, cost)
@@ -226,6 +232,7 @@ class EvccApiBridge:
         try:
             async with self.web_session.ws_connect(self.web_socket_url) as ws:
                 self.ws_connected = True
+                self._ws_LAST_UPDATE = time()  # Set grace period so watchdog doesn't immediately kill connection
                 _LOGGER.info(f"connected to websocket: {self.web_socket_url}")
                 async for msg in ws:
                     if msg.type == aiohttp.WSMsgType.TEXT:
@@ -290,7 +297,6 @@ class EvccApiBridge:
                                                 self._data[key] = value
                                                 _LOGGER.info(f"added '{key}' to self._data and assign: {value}")
 
-
                                 # END of for loop
                                 # _LOGGER.debug(f"key: {key} value: {value}")
                                 if self._debounced_update_task is not None:
@@ -300,6 +306,11 @@ class EvccApiBridge:
 
                         except Exception as e:
                             _LOGGER.info(f"Could not read JSON from: {msg} - caused {e}")
+                            # Ensure we still update the coordinator even if processing failed
+                            if self._debounced_update_task is not None:
+                                self._debounced_update_task.cancel()
+                            self._debounced_update_task = asyncio.create_task(self._debounce_coordinator_update())
+                            self._ws_LAST_UPDATE = time()
 
                     elif msg.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR):
                         _LOGGER.debug(f"received: {msg}")
@@ -317,9 +328,14 @@ class EvccApiBridge:
         self.ws_connected = False
 
     async def _debounce_coordinator_update(self):
-        await asyncio.sleep(0.3)
-        if self.coordinator is not None:
-            self.coordinator.async_set_updated_data(self._data)
+        try:
+            await asyncio.sleep(0.3)
+            if self.coordinator is not None:
+                self.coordinator.async_set_updated_data(self._data)
+        except asyncio.CancelledError:
+            _LOGGER.debug("DEBOUNCE: task was cancelled (normal during reconnect)")
+        except Exception as e:
+            _LOGGER.error(f"DEBOUNCE ERROR: {type(e).__name__}: {e}", exc_info=True)
 
     async def read_all_data(self, request_all:bool=True, request_tariffs:bool=False, request_sessions:bool=False) -> dict:
         if request_all:

--- a/custom_components/evcc_intg/sensor.py
+++ b/custom_components/evcc_intg/sensor.py
@@ -368,7 +368,8 @@ class EvccSensor(EvccBaseEntity, SensorEntity, RestoreEntity):
 
                 elif self.tag == Tag.FORECAST_SOLAR and FORECAST_CONTENT.SOLAR.value in data:
                     a_object = data[FORECAST_CONTENT.SOLAR.value]
-                    if "timeseries" in a_object:
+                    # Fix (masked) exception when a_object is None
+                    if a_object is not None and "timeseries" in a_object:
                         a_copy_object = a_object.copy()
                         a_array = a_copy_object["timeseries"]
                         if a_array is not None and "ts" in a_array[0]:


### PR DESCRIPTION
…n change

The real reason being that processing errors further down were masked but prevented debounced updates completely.

This PR forces updates even on processing errors on some of the values. Also de-noisifies logging in case of valid `None` values.