### PR TITLE
Add holdcharge battery mode option

### DIFF
--- a/custom_components/evcc_intg/pyevcc_ha/const.py
+++ b/custom_components/evcc_intg/pyevcc_ha/const.py
@@ -146,8 +146,9 @@ TRANSLATIONS: Final = {
         "batterymode": {
             "unknown": "Unbekannt",
             "normal": "normal",
-            "hold": "angehalten/gesperrt",
+            "hold": "entladen sperren",
             "charge": "laden...",
+            "holdcharge": "laden sperren",
         },
         "phaseaction":{
             "scale1p": "Reduziere auf einphasig",
@@ -173,8 +174,9 @@ TRANSLATIONS: Final = {
         "batterymode": {
             "unknown": "unknown",
             "normal": "normal",
-            "hold": "on-hold",
+            "hold": "lock discharge",
             "charge": "charging...",
+            "holdcharge": "lock charge",
         },
         "phaseaction":{
             "scale1p": "Reducing to 1-phase charging",

--- a/custom_components/evcc_intg/pyevcc_ha/keys.py
+++ b/custom_components/evcc_intg/pyevcc_ha/keys.py
@@ -85,10 +85,10 @@ class Tag(ApiKey, Enum):
     # "auxPower": 1116.8,
     AUXPOWER = ApiKey(json_key="auxPower", type=EP_TYPE.SITE)
 
-    # "batteryMode": unknown|normal|hold|charge
-    # POST /api/batterymode/<mode>: set battery mode (unknown/normal/hold/charge)
+    # "batteryMode": unknown|normal|hold|charge|holdcharge
+    # POST /api/batterymode/<mode>: set battery mode (unknown/normal/hold/charge/holdcharge)
     # Directly controls the mode of all controllable batteries. evcc behavior like 'price limit' or 'prevent discharge while fast charging' is overruled. External mode resets after 60s. The external system has to call this endpoint regularly.
-    BATTERYMODE = ApiKey(json_key="batteryMode", type=EP_TYPE.SITE, writeable=True, write_key="batterymode", options=["null", "unknown", "normal", "hold", "charge"])
+    BATTERYMODE = ApiKey(json_key="batteryMode", type=EP_TYPE.SITE, writeable=True, write_key="batterymode", options=["null", "unknown", "normal", "hold", "charge", "holdcharge"])
 
     # "battery":[{"power":0,"capacity":12,"soc":81,"controllable":false}], -> we must access this attribute via json_idx
     BATTERY = ApiKey(json_key="battery", type=EP_TYPE.SITE)

--- a/custom_components/evcc_intg/translations/de.json
+++ b/custom_components/evcc_intg/translations/de.json
@@ -117,8 +117,9 @@
           "null": "löschen",
           "unknown": "unbekannt",
           "normal": "normal",
-          "hold": "halten",
-          "charge": "laden"
+          "hold": "entladen sperren",
+          "charge": "laden",
+          "holdcharge": "laden sperren"
         }
       },
       "prioritysoc": {

--- a/custom_components/evcc_intg/translations/en.json
+++ b/custom_components/evcc_intg/translations/en.json
@@ -119,8 +119,9 @@
           "null": "delete",
           "unknown": "unknown",
           "normal": "normal",
-          "hold": "hold",
-          "charge": "charge"
+          "hold": "lock discharge",
+          "charge": "charge",
+          "holdcharge": "lock charge"
         }
       },
       "prioritysoc": {


### PR DESCRIPTION
Add holdcharge as a new battery mode option to the select entity. This mode prevents battery charging while still allowing discharge.

Also update hold/holdcharge translations to use clearer terminology: discharge lock (Entladesperre) and charge lock (Ladesperre).

See https://github.com/evcc-io/evcc/pull/27906