### PR TITLE
Fix TypeError: 'NoneType' has no len() when repeatingPlans is null #294

### DIFF
--- a/custom_components/evcc_intg/__init__.py
+++ b/custom_components/evcc_intg/__init__.py
@@ -900,7 +900,7 @@ class EvccDataUpdateCoordinator(DataUpdateCoordinator):
                        Tag.VEHICLEREPEATINGPLAN005, Tag.VEHICLEREPEATINGPLAN006, Tag.VEHICLEREPEATINGPLAN007,
                        Tag.VEHICLEREPEATINGPLAN008, Tag.VEHICLEREPEATINGPLAN009, Tag.VEHICLEREPEATINGPLAN010]:
 
-            data_obj = self.data[JSONKEY_VEHICLES][vehicle_id].get("repeatingPlans", [])
+            data_obj = self.data[JSONKEY_VEHICLES][vehicle_id].get("repeatingPlans") or []
             data_len = len(data_obj)
             if a_tag == Tag.VEHICLEREPEATINGPLAN002 and data_len > 0:
                 return data_obj[0]
@@ -977,7 +977,7 @@ class EvccDataUpdateCoordinator(DataUpdateCoordinator):
 
             if self.data is not None and evcc_internal_id in self.data[EP_TYPE.VEHICLES.value]:
                 data_obj = self.data[EP_TYPE.VEHICLES.value][evcc_internal_id]
-                if "repeatingPlans" in data_obj:
+                if data_obj.get("repeatingPlans"):
                     post_data = copy.deepcopy(data_obj["repeatingPlans"])
                     post_data_len = len(post_data)
                     new_state = str(value) == "1"


### PR DESCRIPTION
After the "REPEATING PLANS" change (commit `70d3bbc`), the integration crashes on **every** coordinator update cycle for vehicles that have no repeating plans configured. The Home Assistant log is flooded with identical stack traces:

```
ERROR (MainThread) [custom_components.evcc_intg] Unexpected error updating listener ... for evcc_intg
Traceback (most recent call last):
  ...
  File "/config/custom_components/evcc_intg/switch.py", line 168, in available
    value = self.coordinator.read_tag(self.tag, self.lp_idx, self.evcc_internal_id)
  File "/config/custom_components/evcc_intg/__init__.py", line 730, in read_tag
    ret = self.read_tag_vehicle_int(a_tag=a_tag, loadpoint_idx=idx, vehicle_id=evcc_internal_id)
  File "/config/custom_components/evcc_intg/__init__.py", line 867, in read_tag_vehicle_int
    return self.read_tag_vehicle_str(a_tag=a_tag, vehicle_id=vehicle_id)
  File "/config/custom_components/evcc_intg/__init__.py", line 904, in read_tag_vehicle_str
    data_len = len(data_obj)
TypeError: object of type 'NoneType' has no len()
```

## Root cause

The evcc API does **not** omit the `repeatingPlans` key when a vehicle has no repeating plans. It returns the key with an explicit `null` value:

```json
"repeatingPlans": null
```

`dict.get("repeatingPlans", [])` only falls back to the `[]` default when the **key is absent**. Because the key is present with value `null`, `.get()` returns `None`, and the subsequent `len(None)` raises the `TypeError`. Since this runs on every update cycle (via `switch.py:available`), the log fills up continuously.

The write path (`async_press_tag`, repeatingPlans patch block) has the same latent bug: `"repeatingPlans" in data_obj` evaluates to `True` even when the value is `None`, so `copy.deepcopy(None)` → `None` → `len(None)` would fail there as well.

## Fix

Treat a `null` value like an empty list in both places:

```diff
@@ read_tag_vehicle_str
-            data_obj = self.data[JSONKEY_VEHICLES][vehicle_id].get("repeatingPlans", [])
+            data_obj = self.data[JSONKEY_VEHICLES][vehicle_id].get("repeatingPlans") or []
             data_len = len(data_obj)

@@ async_press_tag (repeatingPlans patch block)
-                if "repeatingPlans" in data_obj:
+                if data_obj.get("repeatingPlans"):
                     post_data = copy.deepcopy(data_obj["repeatingPlans"])
                     post_data_len = len(post_data)
```