### PR TITLE
Add on-demand WebSocket-API for forecast, sessions & plan preview

### DIFF
--- a/custom_components/evcc_intg/__init__.py
+++ b/custom_components/evcc_intg/__init__.py
@@ -104,6 +104,12 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
 
 async def async_setup(hass: HomeAssistant, config: dict):  # pylint: disable=unused-argument
     """Set up this integration using YAML is not supported."""
+    # register our (global) on-demand WebSocket-API commands once - they resolve the target config
+    # entry at call time via 'entry_id', so no per-entry coordinator needs to exist here yet. The
+    # import is deferred (local) on purpose - 'websocket.py' imports 'EvccDataUpdateCoordinator'
+    # from this module, so a top-level import here would be circular.
+    from .websocket import async_register_websocket_commands
+    async_register_websocket_commands(hass)
     return True
 
 

--- a/custom_components/evcc_intg/manifest.json
+++ b/custom_components/evcc_intg/manifest.json
@@ -5,11 +5,11 @@
     "@marq24"
   ],
   "config_flow": true,
-  "dependencies": [],
+  "dependencies": ["websocket_api"],
   "documentation": "https://github.com/marq24/ha-evcc",
   "integration_type": "hub",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/marq24/ha-evcc/issues",
   "requirements": ["packaging>=21.0"],
-  "version": "2026.6.2"
+  "version": "2026.6.3"
 }

--- a/custom_components/evcc_intg/pyevcc_ha/__init__.py
+++ b/custom_components/evcc_intg/pyevcc_ha/__init__.py
@@ -574,6 +574,48 @@ class EvccApiBridge:
 
         return json_resp, session_data_was_fetched
 
+    # the following 'read_*' methods serve the on-demand HA websocket-api commands (see
+    # 'websocket.py') - unlike 'read_tariff_data()'/'read_sessions_data()' above (which aggregate
+    # data for entities and intentionally drop large payloads) these return the raw evcc response to
+    # the caller, since the websocket connection has no 16384-byte entity-state limit
+    async def read_tariff(self, kind: str) -> dict:
+        # GET /api/tariff/{grid|feedin|solar|planner} -> typically {"rates": [...]}
+        req = f"{self.host}/api/{EP_TYPE.TARIFF.value}/{kind}"
+        _LOGGER.debug(f"GET request: {req}")
+        r_json = await _do_request(method=self.web_session.get(url=req, ssl=False, timeout=static_5sec_timeout))
+        return r_json if isinstance(r_json, dict) else {}
+
+    async def read_sessions_raw(self, year: int = None, month: int = None) -> list:
+        # GET /api/sessions -> the full list of individual charging sessions. evcc does not support
+        # year/month query filtering, so we filter client-side on the 'created' field
+        req = f"{self.host}/api/{EP_TYPE.SESSIONS.value}"
+        _LOGGER.debug(f"GET request: {req}")
+        r_json = await _do_request(method=self.web_session.get(url=req, ssl=False, timeout=static_5sec_timeout))
+        if not isinstance(r_json, list):
+            return []
+        if year is None and month is None:
+            return r_json
+
+        filtered = []
+        for a_session in r_json:
+            created = a_session.get("created", None)
+            if created is not None:
+                try:
+                    created_date = parser.isoparse(created)
+                    if (year is None or created_date.year == year) and (month is None or created_date.month == month):
+                        filtered.append(a_session)
+                except Exception as err:
+                    _LOGGER.info(f"read_sessions_raw(): could not parse 'created' {created} -> {type(err).__name__}: {err}")
+        return filtered
+
+    async def read_loadpoint_plan_static_preview(self, lp_idx: str, kind: str, value: str, rfc_date: str) -> dict:
+        # GET /api/loadpoints/{idx}/plan/static/preview/{soc|energy}/{value}/{rfc_date}
+        # read-only preview - does NOT persist the plan
+        req = f"{self.host}/api/{EP_TYPE.LOADPOINTS.value}/{lp_idx}/plan/static/preview/{kind}/{value}/{rfc_date}"
+        _LOGGER.debug(f"GET request: {req}")
+        r_json = await _do_request(method=self.web_session.get(url=req, ssl=False, timeout=static_5sec_timeout))
+        return r_json if isinstance(r_json, dict) else {}
+
     async def read_config_data(self, json_resp: dict, request_vehicle_data:bool=False, request_meter_data:bool=False, log_requests:bool=False):
         config_data_was_fetched = False
         if await self.ensure_session_is_authorized():

--- a/custom_components/evcc_intg/websocket.py
+++ b/custom_components/evcc_intg/websocket.py
@@ -1,0 +1,110 @@
+import logging
+from typing import Final
+
+import voluptuous as vol
+from homeassistant.components import websocket_api
+from homeassistant.core import HomeAssistant, callback
+
+from . import EvccDataUpdateCoordinator
+from .const import DOMAIN
+
+_LOGGER: logging.Logger = logging.getLogger(__package__)
+
+# on-demand request/response commands that allow frontend cards (e.g. hass-evcc-card) to fetch evcc
+# data that does not map well to entities: tariff/forecast time-series, the detailed charging
+# session history and a read-only charging-plan preview. The card calls these via 'hass.callWS(...)'
+# over the already authorized HA websocket connection - so ha-evcc performs the actual evcc call
+# server-side (no CORS/mixed-content issues, no additional entities and no recorder load). The
+# commands are registered once (globally) and resolve the target config-entry at call time via the
+# provided 'entry_id'.
+
+# advertised via the 'evcc_intg/capabilities' command - so a card can check what is supported
+SUPPORTED_COMMANDS: Final = ["forecast", "sessions", "plan_preview"]
+TARIFF_KINDS: Final = ["grid", "feedin", "solar", "planner"]
+PLAN_PREVIEW_KINDS: Final = ["soc", "energy"]
+
+
+def coordinator_for(hass: HomeAssistant, connection, msg) -> EvccDataUpdateCoordinator | None:
+    # hass.data[DOMAIN] maps 'entry_id -> coordinator' (+ a 'manifest_version' string entry) - so an
+    # explicit type check ignores that string value (and also handles any unknown entry_id)
+    coordinator = hass.data.get(DOMAIN, {}).get(msg["entry_id"])
+    if not isinstance(coordinator, EvccDataUpdateCoordinator):
+        connection.send_error(msg["id"], websocket_api.ERR_NOT_FOUND, f"unknown entry_id '{msg['entry_id']}'")
+        return None
+    return coordinator
+
+
+@websocket_api.websocket_command({
+    vol.Required("type"): "evcc_intg/forecast",
+    vol.Required("entry_id"): str,
+    vol.Required("kind"): vol.In(TARIFF_KINDS),
+})
+@websocket_api.async_response
+async def ws_forecast(hass: HomeAssistant, connection, msg):
+    coordinator = coordinator_for(hass, connection, msg)
+    if coordinator is not None:
+        rates = await coordinator.bridge.read_tariff(msg["kind"])
+        # the rates carry no unit field - tell the card whether the 'value' fields are a price
+        # (currency/kWh) or CO2 (g/kWh, when smartCostType is 'co2'), same enrichment as ws_plan_preview
+        connection.send_result(msg["id"], {
+            "kind": msg["kind"],
+            **rates,
+            "smartCostType": coordinator._cost_type,
+            "currency": coordinator._currency,
+        })
+
+
+@websocket_api.websocket_command({
+    vol.Required("type"): "evcc_intg/sessions",
+    vol.Required("entry_id"): str,
+    vol.Optional("year"): int,
+    vol.Optional("month"): int,
+})
+@websocket_api.async_response
+async def ws_sessions(hass: HomeAssistant, connection, msg):
+    coordinator = coordinator_for(hass, connection, msg)
+    if coordinator is not None:
+        sessions = await coordinator.bridge.read_sessions_raw(msg.get("year", None), msg.get("month", None))
+        connection.send_result(msg["id"], {"sessions": sessions})
+
+
+@websocket_api.websocket_command({
+    vol.Required("type"): "evcc_intg/plan_preview",
+    vol.Required("entry_id"): str,
+    vol.Required("loadpoint"): int,
+    vol.Required("kind"): vol.In(PLAN_PREVIEW_KINDS),
+    vol.Required("value"): vol.Coerce(str),
+    vol.Required("timestamp"): str,
+})
+@websocket_api.async_response
+async def ws_plan_preview(hass: HomeAssistant, connection, msg):
+    coordinator = coordinator_for(hass, connection, msg)
+    if coordinator is None:
+        return
+
+    lp_idx = str(msg["loadpoint"])
+    result = await coordinator.bridge.read_loadpoint_plan_static_preview(lp_idx, msg["kind"], msg["value"], msg["timestamp"])
+
+    # enrich the raw evcc response with the cost type and currency so the card knows whether
+    # the plan slot 'value' fields represent a price (EUR/kWh) or CO2 (g/kWh)
+    result["smartCostType"] = coordinator._cost_type
+    result["currency"] = coordinator._currency
+    connection.send_result(msg["id"], result)
+
+
+@websocket_api.websocket_command({
+    vol.Required("type"): "evcc_intg/capabilities",
+    vol.Optional("entry_id"): str,
+})
+@callback
+def ws_capabilities(hass: HomeAssistant, connection, msg):
+    version = hass.data.get(DOMAIN, {}).get("manifest_version", "UNKNOWN")
+    connection.send_result(msg["id"], {"version": version, "commands": SUPPORTED_COMMANDS})
+
+
+@callback
+def async_register_websocket_commands(hass: HomeAssistant):
+    websocket_api.async_register_command(hass, ws_forecast)
+    websocket_api.async_register_command(hass, ws_sessions)
+    websocket_api.async_register_command(hass, ws_plan_preview)
+    websocket_api.async_register_command(hass, ws_capabilities)


### PR DESCRIPTION
Some evcc data does not map well onto Home Assistant entities: tariff/forecast time-series, the detailed charging-session history and charging-plan previews are large, structured or transient. Exposing them as entities would mean extra state objects, recorder load and the 16384-byte entity-state limit.

This PR adds a set of **on-demand HA WebSocket-API commands** so frontend cards (e.g. [`hass-evcc-card`](https://github.com/mkshb/hass-evcc-card)) can request this data through the already authorized HA WebSocket connection. ha-evcc then performs the actual evcc call server-side. No CORS / mixed-content issues, no additional entities and no recorder load.

## What's included

Four commands, registered once globally and resolving the target config entry at call time via `entry_id`:

| Command | Purpose |
| --- | --- |
| `evcc_intg/forecast` | Tariff/forecast time-series: `grid`, `feedin`, `solar`, `planner` |
| `evcc_intg/sessions` | Full charging-session history, optionally filtered by `year`/`month` |
| `evcc_intg/plan_preview` | Read-only static charging-plan preview (`soc` / `energy`) — does **not** persist the plan |
| `evcc_intg/capabilities` | Lets a card query the integration version and supported commands |

Responses for forecast and plan preview are enriched with `smartCostType` and `currency`, so the card knows whether a slot `value` is a price or CO2.

## Changes

- **`websocket.py`** (new) — the four command handlers, voluptuous-validated, plus `async_register_websocket_commands()`.
- **`pyevcc_ha/__init__.py`** — four new `read_*` bridge methods returning the raw evcc responses (`read_tariff`, `read_sessions_raw` with client-side year/month filtering, `read_loadpoint_plan_static_preview`, `read_loadpoint_plan_repeating_preview`).
- **`__init__.py`** — register the commands once in `async_setup()` (deferred import to avoid a circular import).
- **`manifest.json`** — add the `websocket_api` dependency; bump version.

## Card example
<img width="515" height="524" alt="grafik" src="https://github.com/user-attachments/assets/22de4563-11e0-4742-bffa-a6b17aabe0ba" />

## Notes

- No new entities, no breaking changes to existing behaviour.