### PR TITLE
cache reads and invalidate sessions on charging stop

### DIFF
--- a/custom_components/evcc_intg/pyevcc_ha/__init__.py
+++ b/custom_components/evcc_intg/pyevcc_ha/__init__.py
@@ -328,6 +328,14 @@ class EvccApiBridge:
                                                 if len(self._data[domain]) > idx:
                                                     if not sub_key in self._data[domain][idx]:
                                                         _LOGGER.debug(f"adding '{sub_key}' to {domain}[{idx}]")
+                                                    # a loadpoint 'charging' transition true->false means a charging
+                                                    # session has just finished - evcc creates the session record now,
+                                                    # so we invalidate our sessions update-window: the additional-data
+                                                    # task launched after this loop will then refetch /api/sessions
+                                                    if domain == JSONKEY_LOADPOINTS and sub_key == Tag.CHARGING.json_key \
+                                                            and self._data[domain][idx].get(sub_key) is True and value is False:
+                                                        _LOGGER.debug(f"loadpoint[{idx}] charging stopped -> force sessions refresh")
+                                                        self._SESSIONS_LAST_UPDATE_HOUR = -1
                                                     self._data[domain][idx][sub_key] = value
                                                 else:
                                                     # we need to add a new entry to the list... - well
@@ -1363,7 +1371,7 @@ class EvccApiBridge:
         # first we check if we already have the tariff data in our storage...
         r_json = None
         if self._data is not None:
-            if not ADDITIONAL_ENDPOINTS_DATA_TARIFF in self.data:
+            if not ADDITIONAL_ENDPOINTS_DATA_TARIFF in self._data:
                 self._data[ADDITIONAL_ENDPOINTS_DATA_TARIFF] = {}
 
             if kind in self._data[ADDITIONAL_ENDPOINTS_DATA_TARIFF]:
@@ -1399,14 +1407,17 @@ class EvccApiBridge:
         # integration will make the request to the session endpoint
 
         # first we check if we already have the sessions in our storage...
-        if self._data is not None and ADDITIONAL_ENDPOINTS_DATA_SESSIONS_RAW in self.data:
+        if self._data is not None and ADDITIONAL_ENDPOINTS_DATA_SESSIONS_RAW in self._data:
             r_json = self._data[ADDITIONAL_ENDPOINTS_DATA_SESSIONS_RAW]
             session_data_was_fetched = True
 
         else:
             if self._data is None:
                 self._data = {}
-            r_json, session_data_was_fetched = self.read_sessions_data(self._data)
+            # read_sessions_data() is async and returns (json_resp, was_fetched) - it stores the raw
+            # list under ADDITIONAL_ENDPOINTS_DATA_SESSIONS_RAW in the passed dict, so read it back
+            self._data, session_data_was_fetched = await self.read_sessions_data(self._data)
+            r_json = self._data.get(ADDITIONAL_ENDPOINTS_DATA_SESSIONS_RAW)
 
         if not session_data_was_fetched or not isinstance(r_json, list):
             return []


### PR DESCRIPTION
Follow up to the caching rework in #298. While testing the new cached commands locally I hit two bugs that made `forecast` and `sessions` unusable, and I added the session invalidation that was flagged for me in the code. 

## Changes

1. **Fix the `AttributeError` that broke every `forecast` and `sessions` call.** `evcc_card_read_tariff` and `evcc_card_read_sessions_raw` referenced `self.data`, but the bridge only has `self._data` (the `.data` property lives on the coordinator, not on `EvccApiBridge`). Both commands raised `AttributeError: 'EvccApiBridge' object has no attribute 'data'` on the warm path, so they failed on every call. Changed both to `self._data`.

2. **Fix the cold cache branch of `evcc_card_read_sessions_raw`.** `read_sessions_data` is an `async def` returning `(json_resp, was_fetched)`, but it was called without `await`, and its first return value (the whole data dict) was treated as the session list. It now awaits the call and reads the raw list back from `self._data[ADDITIONAL_ENDPOINTS_DATA_SESSIONS_RAW]`.

3. **Invalidate the sessions cache when a charging session ends.** In the `connect_ws` message handler, when a loadpoint `charging` value goes from true to false, set `self._SESSIONS_LAST_UPDATE_HOUR = -1` so the additional data task launched right after the message loop refetches `/api/sessions`. This is the hook flagged in the code comment, so a session that ends mid hour shows up  on the next cycle instead of waiting for the top of the hour.

## Testing

Verified locally against Home Assistant with evcc 0.309.2:

- Before: `forecast` and `sessions` returned `unknown_error` on every call (the `self.data` AttributeError). After: both return data.
- Cache proof (bridge debug logging on): in a single run, 2 `plan_preview` calls produced exactly 2 `GET request: .../plan/static/preview` log lines (positive control), while 8 `sessions` calls and 8 `forecast` calls produced 0 backend GETs. So `forecast` and `sessions` serve from cache and never hit the evcc backend per card call.
- `plan_preview` keeps making one live call per request by design.

## Open status

The session invalidation in change 3 is in place but was not exercised live, because it needs a real charging session to stop during the test window. The surrounding merge logic is covered by the cache tests, but the `charging` true to false trigger itself has only been verified statically. On the next real session end the log should show `loadpoint[x] charging stopped -> force sessions refresh` followed by a single `GET request: .../api/sessions`. I will confirm that once it happens.
The card side change for `plan_preview` (debounce plus the existing 60 s client cache) will follow in hass-evcc-card once this has landed and been released.

